### PR TITLE
Add umbrella to the list of no point labels

### DIFF
--- a/card.py
+++ b/card.py
@@ -24,7 +24,7 @@ WORKFLOW_LABELS = ['bucket', 'ready', 'in progress', 'review',
 POINTSUM_COLUMNS = [COLUMNS.READY, COLUMNS.IN_PROGRESS, COLUMNS.REVIEW, COLUMNS.COMPLETE, COLUMNS.IMPEDED]
 ZERO_POINT_LABELS = {'training', 'HLM', 'Cryomagnet', 'Friday',
                      'Datastreaming', 'standdown', 'support'}
-NO_POINT_LABELS = {'support', 'duplicate', 'sub-ticket', 'wontfix'}
+NO_POINT_LABELS = {'support', 'duplicate', 'sub-ticket', 'umbrella', 'wontfix'}
 
 NUM_ERROR = 0
 NUM_WARNING = 0


### PR DESCRIPTION
Having added the `umbrella` label to allow for those tickets which have pointed sub-tickets but no points of their own, it needs adding to the list of `no point` labels